### PR TITLE
Upgrade actions/upload-artifact to v4 to avoid deprecation issues

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -42,7 +42,7 @@ jobs:
         run: python generate_csv.py
 
       - name: Upload output file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Output
           path: |


### PR DESCRIPTION
The scheduled task failed with the following error message:

>This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

To resolve this issue, I updated the workflow’s YAML file to use actions/upload-artifact@v4.